### PR TITLE
Compatibility with Tweaks55 scroll speed multiplier

### DIFF
--- a/StickDriftHelper/Patches/Stick.cs
+++ b/StickDriftHelper/Patches/Stick.cs
@@ -27,6 +27,7 @@ namespace StickDriftHelper.Patches
         [HarmonyPatch("HandleJoystickWasNotCenteredThisFrame")]
         internal class ScrollViewStickDrift
         {
+            [HarmonyBefore(new string[] { "Kinsi55.BeatSaber.Tweaks55" })]
             static bool Prefix(ScrollView __instance, ref Vector2 deltaPos)
             {
                 if (!Config.Instance.Enabled) return true;


### PR DESCRIPTION
With StickDriftHelper enabled, the "Joystick Scroll speed multiplier" feature in [Tweaks55](https://github.com/kinsi55/BeatSaber_Tweaks55) was no longer working.

[Their Harmony patch](https://github.com/kinsi55/BeatSaber_Tweaks55/blob/master/HarmonyPatches/OverrideMaxScrollSpeed.cs) simply multiplies the deltaPos vector, but it was being called first so then the StickDriftHelper patch normalizes the vector back to a maximum length of 1.0

This change makes Harmony run the StickDriftHelper prefix before the Tweaks55 prefix, which allows them to work properly together.